### PR TITLE
Update FacetSet.php

### DIFF
--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -37,11 +37,21 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         if (0 !== count($facets)) {
             $non_json = false;
             $json_facets = [];
+
+            // create a list of facet fields
+            // 1) filter for FACET_FIELD
+            // 2) get field name
+            // 3) count occurence
+            $facet_fields = array_count_values( array_map( function( $value ) {
+                  return $value->getField();
+              }, array_filter( $facets, function( $value ) {
+                  return $value->getType() == FacetSetInterface::FACET_FIELD;
+                })));
             foreach ($facets as $key => $facet) {
                 switch ($facet->getType()) {
                     case FacetSetInterface::FACET_FIELD:
                         /* @var FacetField $facet */
-                        $this->addFacetField($request, $facet);
+                        $this->addFacetField($request, $facet, ($facet_fields[$facet->getField()] == 1));
                         $non_json = true;
                         break;
                     case FacetSetInterface::FACET_QUERY:
@@ -108,16 +118,34 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      *
      * @param Request    $request
      * @param FacetField $facet
+     * @param compatible $compatible false if local parameters should be used
      */
-    public function addFacetField($request, $facet)
+    public function addFacetField($request, $facet, $compatible = true)
     {
         $field = $facet->getField();
 
+        if( $compatible )
+        {
+          $request->addParam("f.$field.facet.limit", $facet->getLimit());
+          $request->addParam("f.$field.facet.sort", $facet->getSort());
+          $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+          $request->addParam("f.$field.facet.contains", $facet->getContains());
+          $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+          $request->addParam("f.$field.facet.offset", $facet->getOffset());
+          $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+          $request->addParam("f.$field.facet.missing", $facet->getMissing());
+          $request->addParam("f.$field.facet.method", $facet->getMethod());
+          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
+        }
+        else
+        {
+          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
+        }
         $request->addParam(
             'facet.field',
             $this->renderLocalParams(
                 $field,
-                ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()]
+                $local_param
             )
         );
     }

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -120,15 +120,11 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
      * @param FacetField $facet
      * @param compatible $compatible false if local parameters should be used
      */
-    public function addFacetField($request, $facet, $compatible = true)
+    public function addFacetField($request, $facet, $compatibility_mode = true)
     {
         $field = $facet->getField();
 
-        if ($compatible) {
-            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
-        } else {
-            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
-        }
+        $local_param = $compatibility_mode ? ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()] : ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
         $request->addParam(
             'facet.field',
             $this->renderLocalParams(
@@ -136,7 +132,7 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
                 $local_param
             )
         );
-        if ($compatible) {
+        if ($compatibility_mode) {
             $request->addParam("f.$field.facet.limit", $facet->getLimit());
             $request->addParam("f.$field.facet.sort", $facet->getSort());
             $request->addParam("f.$field.facet.prefix", $facet->getPrefix());

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -43,15 +43,15 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             // 2) get field name
             // 3) count occurence
             $facet_fields = array_count_values( array_map( function( $value ) {
-                  return $value->getField();
-              }, array_filter( $facets, function( $value ) {
-                  return $value->getType() == FacetSetInterface::FACET_FIELD;
-                })));
+                return $value->getField();
+            }, array_filter( $facets, function( $value ) {
+                return $value->getType() == FacetSetInterface::FACET_FIELD;
+            })));
             foreach ($facets as $key => $facet) {
                 switch ($facet->getType()) {
                     case FacetSetInterface::FACET_FIELD:
                         /* @var FacetField $facet */
-                        $this->addFacetField($request, $facet, ($facet_fields[$facet->getField()] == 1));
+                        $this->addFacetField($request, $facet, (1 == $facet_fields[$facet->getField()]));
                         $non_json = true;
                         break;
                     case FacetSetInterface::FACET_QUERY:
@@ -126,20 +126,20 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         if( $compatible )
         {
-          $request->addParam("f.$field.facet.limit", $facet->getLimit());
-          $request->addParam("f.$field.facet.sort", $facet->getSort());
-          $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-          $request->addParam("f.$field.facet.contains", $facet->getContains());
-          $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-          $request->addParam("f.$field.facet.offset", $facet->getOffset());
-          $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-          $request->addParam("f.$field.facet.missing", $facet->getMissing());
-          $request->addParam("f.$field.facet.method", $facet->getMethod());
-          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
+            $request->addParam("f.$field.facet.limit", $facet->getLimit());
+            $request->addParam("f.$field.facet.sort", $facet->getSort());
+            $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+            $request->addParam("f.$field.facet.contains", $facet->getContains());
+            $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+            $request->addParam("f.$field.facet.offset", $facet->getOffset());
+            $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+            $request->addParam("f.$field.facet.missing", $facet->getMissing());
+            $request->addParam("f.$field.facet.method", $facet->getMethod());
+            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
         }
         else
         {
-          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
+            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
         }
         $request->addParam(
             'facet.field',

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -43,15 +43,15 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             // 2) get field name
             // 3) count occurence
             $facet_fields = array_count_values( array_map( function( $value ) {
-                return $value->getField();
-            }, array_filter( $facets, function( $value ) {
-                return $value->getType() == FacetSetInterface::FACET_FIELD;
-            })));
+                  return $value->getField();
+              }, array_filter( $facets, function( $value ) {
+                  return $value->getType() == FacetSetInterface::FACET_FIELD;
+                })));
             foreach ($facets as $key => $facet) {
                 switch ($facet->getType()) {
                     case FacetSetInterface::FACET_FIELD:
                         /* @var FacetField $facet */
-                        $this->addFacetField($request, $facet, (1 == $facet_fields[$facet->getField()]));
+                        $this->addFacetField($request, $facet, ($facet_fields[$facet->getField()] == 1));
                         $non_json = true;
                         break;
                     case FacetSetInterface::FACET_QUERY:
@@ -126,20 +126,20 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         if( $compatible )
         {
-            $request->addParam("f.$field.facet.limit", $facet->getLimit());
-            $request->addParam("f.$field.facet.sort", $facet->getSort());
-            $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-            $request->addParam("f.$field.facet.contains", $facet->getContains());
-            $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-            $request->addParam("f.$field.facet.offset", $facet->getOffset());
-            $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-            $request->addParam("f.$field.facet.missing", $facet->getMissing());
-            $request->addParam("f.$field.facet.method", $facet->getMethod());
-            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
+          $request->addParam("f.$field.facet.limit", $facet->getLimit());
+          $request->addParam("f.$field.facet.sort", $facet->getSort());
+          $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+          $request->addParam("f.$field.facet.contains", $facet->getContains());
+          $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+          $request->addParam("f.$field.facet.offset", $facet->getOffset());
+          $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+          $request->addParam("f.$field.facet.missing", $facet->getMissing());
+          $request->addParam("f.$field.facet.method", $facet->getMethod());
+          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
         }
         else
         {
-            $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
+          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
         }
         $request->addParam(
             'facet.field',

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -43,10 +43,10 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             // 2) get field name
             // 3) count occurence
             $facet_fields = array_count_values( array_map( function( $value ) {
-                  return $value->getField();
-              }, array_filter( $facets, function( $value ) {
-                  return $value->getType() == FacetSetInterface::FACET_FIELD;
-                })));
+                return $value->getField();
+            }, array_filter( $facets, function( $value ) {
+                return $value->getType() == FacetSetInterface::FACET_FIELD;
+            })));
             foreach ($facets as $key => $facet) {
                 switch ($facet->getType()) {
                     case FacetSetInterface::FACET_FIELD:
@@ -126,20 +126,20 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         if( $compatible )
         {
-          $request->addParam("f.$field.facet.limit", $facet->getLimit());
-          $request->addParam("f.$field.facet.sort", $facet->getSort());
-          $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-          $request->addParam("f.$field.facet.contains", $facet->getContains());
-          $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-          $request->addParam("f.$field.facet.offset", $facet->getOffset());
-          $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-          $request->addParam("f.$field.facet.missing", $facet->getMissing());
-          $request->addParam("f.$field.facet.method", $facet->getMethod());
-          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
+			$request->addParam("f.$field.facet.limit", $facet->getLimit());
+			$request->addParam("f.$field.facet.sort", $facet->getSort());
+			$request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+			$request->addParam("f.$field.facet.contains", $facet->getContains());
+			$request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+			$request->addParam("f.$field.facet.offset", $facet->getOffset());
+			$request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+			$request->addParam("f.$field.facet.missing", $facet->getMissing());
+			$request->addParam("f.$field.facet.method", $facet->getMethod());
+			$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
         }
         else
         {
-          $local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
+			$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
         }
         $request->addParam(
             'facet.field',

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -126,20 +126,11 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
 
         if( $compatible )
         {
-			$request->addParam("f.$field.facet.limit", $facet->getLimit());
-			$request->addParam("f.$field.facet.sort", $facet->getSort());
-			$request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-			$request->addParam("f.$field.facet.contains", $facet->getContains());
-			$request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-			$request->addParam("f.$field.facet.offset", $facet->getOffset());
-			$request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-			$request->addParam("f.$field.facet.missing", $facet->getMissing());
-			$request->addParam("f.$field.facet.method", $facet->getMethod());
-			$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
+		$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()];
         }
         else
         {
-			$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
+		$local_param = ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()];
         }
         $request->addParam(
             'facet.field',
@@ -148,6 +139,18 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
                 $local_param
             )
         );
+        if( $compatible )
+        {
+		$request->addParam("f.$field.facet.limit", $facet->getLimit());
+		$request->addParam("f.$field.facet.sort", $facet->getSort());
+		$request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+		$request->addParam("f.$field.facet.contains", $facet->getContains());
+		$request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+		$request->addParam("f.$field.facet.offset", $facet->getOffset());
+		$request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+		$request->addParam("f.$field.facet.missing", $facet->getMissing());
+		$request->addParam("f.$field.facet.method", $facet->getMethod());
+        }
     }
 
     /**

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -117,19 +117,30 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             'facet.field',
             $this->renderLocalParams(
                 $field,
-                ['key' => $facet->getKey(), 'ex' => $facet->getExcludes()]
+                ['key' => $facet->getKey()
+                  , 'ex' => $facet->getExcludes()
+                  , 'facet.limit' => $facet->getLimit()
+                  , 'facet.sort' => $facet->getSort()
+                  , 'facet.prefix' => $facet->getPrefix()
+                  , 'facet.contains' => $facet->getContains()
+                  , 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase()
+                  , 'facet.offset' => $facet->getOffset()
+                  , 'facet.mincount' => $facet->getMinCount()
+                  , 'facet.missing' => $facet->getMissing()
+                  , 'facet.method' => $facet->getMethod()
+                ]
             )
         );
 
-        $request->addParam("f.$field.facet.limit", $facet->getLimit());
-        $request->addParam("f.$field.facet.sort", $facet->getSort());
-        $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-        $request->addParam("f.$field.facet.contains", $facet->getContains());
-        $request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-        $request->addParam("f.$field.facet.offset", $facet->getOffset());
-        $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-        $request->addParam("f.$field.facet.missing", $facet->getMissing());
-        $request->addParam("f.$field.facet.method", $facet->getMethod());
+        //$request->addParam("f.$field.facet.limit", $facet->getLimit());
+        //$request->addParam("f.$field.facet.sort", $facet->getSort());
+        //$request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+        //$request->addParam("f.$field.facet.contains", $facet->getContains());
+        //$request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
+        //$request->addParam("f.$field.facet.offset", $facet->getOffset());
+        //$request->addParam("f.$field.facet.mincount", $facet->getMinCount());
+        //$request->addParam("f.$field.facet.missing", $facet->getMissing());
+        //$request->addParam("f.$field.facet.method", $facet->getMethod());
     }
 
     /**

--- a/src/Component/RequestBuilder/FacetSet.php
+++ b/src/Component/RequestBuilder/FacetSet.php
@@ -117,30 +117,9 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             'facet.field',
             $this->renderLocalParams(
                 $field,
-                ['key' => $facet->getKey()
-                  , 'ex' => $facet->getExcludes()
-                  , 'facet.limit' => $facet->getLimit()
-                  , 'facet.sort' => $facet->getSort()
-                  , 'facet.prefix' => $facet->getPrefix()
-                  , 'facet.contains' => $facet->getContains()
-                  , 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase()
-                  , 'facet.offset' => $facet->getOffset()
-                  , 'facet.mincount' => $facet->getMinCount()
-                  , 'facet.missing' => $facet->getMissing()
-                  , 'facet.method' => $facet->getMethod()
-                ]
+                ['key' => $facet->getKey(), 'ex' => $facet->getExcludes(), 'facet.limit' => $facet->getLimit(), 'facet.sort' => $facet->getSort(), 'facet.prefix' => $facet->getPrefix(), 'facet.contains' => $facet->getContains(), 'facet.contains.ignoreCase' => $facet->getContainsIgnoreCase(), 'facet.offset' => $facet->getOffset(), 'facet.mincount' => $facet->getMinCount(), 'facet.missing' => $facet->getMissing(), 'facet.method' => $facet->getMethod()]
             )
         );
-
-        //$request->addParam("f.$field.facet.limit", $facet->getLimit());
-        //$request->addParam("f.$field.facet.sort", $facet->getSort());
-        //$request->addParam("f.$field.facet.prefix", $facet->getPrefix());
-        //$request->addParam("f.$field.facet.contains", $facet->getContains());
-        //$request->addParam("f.$field.facet.contains.ignoreCase", $facet->getContainsIgnoreCase());
-        //$request->addParam("f.$field.facet.offset", $facet->getOffset());
-        //$request->addParam("f.$field.facet.mincount", $facet->getMinCount());
-        //$request->addParam("f.$field.facet.missing", $facet->getMissing());
-        //$request->addParam("f.$field.facet.method", $facet->getMethod());
     }
 
     /**

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -298,7 +298,7 @@ class FacetSetTest extends TestCase
         );
 
         static::assertEquals(
-            '?facet.field={!key=f1}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet.field={!key=f4 facet.prefix=X}owner&facet=true&facet.missing=true&facet.limit=10',
+            '?facet.field={!key=f1}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet.field={!key=f5 facet.prefix=X}owner&facet=true&facet.missing=true&facet.limit=10',
             urldecode($request->getUri())
         );
     }

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -374,7 +374,7 @@ class FacetSetTest extends TestCase
         $this->assertNull($request->getRawData());
 
         $this->assertEquals(
-            '?facet.field={!key=f1 facet.contains=foo facet.contains.ignoreCase=1}owner&facet=true&facet.contains=bar&facet.contains.ignoreCase=false',
+            '?facet.field={!key=f1}owner&f.owner.facet.contains=foo&f.owner.facet.contains.ignoreCase=true&facet=true&facet.contains=bar&facet.contains.ignoreCase=false',
             urldecode($request->getUri())
         );
     }

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -288,6 +288,7 @@ class FacetSetTest extends TestCase
         $this->component->addFacet(
             new FacetMultiQuery(['key' => 'f3', 'query' => ['f4' => ['query' => 'category:40']]])
         );
+        $this->component->addFacet(new FacetField(['key' => 'f5', 'field' => 'owner', 'pefix'=>'X']));
 
         $request = $this->builder->buildComponent($this->component, $this->request);
 
@@ -297,7 +298,7 @@ class FacetSetTest extends TestCase
         );
 
         static::assertEquals(
-            '?facet.field={!key=f1}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet=true&facet.missing=true&facet.limit=10',
+            '?facet.field={!key=f1}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet.field={!key=f4 facet.prefix=X}owner&facet=true&facet.missing=true&facet.limit=10',
             urldecode($request->getUri())
         );
     }

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -288,7 +288,7 @@ class FacetSetTest extends TestCase
         $this->component->addFacet(
             new FacetMultiQuery(['key' => 'f3', 'query' => ['f4' => ['query' => 'category:40']]])
         );
-        $this->component->addFacet(new FacetField(['key' => 'f5', 'field' => 'owner', 'pefix' => 'X']));
+        $this->component->addFacet((new FacetField(['key' => 'f5', 'field' => 'owner']))->setPrefix('X'));
 
         $request = $this->builder->buildComponent($this->component, $this->request);
 
@@ -298,7 +298,7 @@ class FacetSetTest extends TestCase
         );
 
         static::assertEquals(
-            '?facet.field={!key=f1}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet.field={!key=f5 facet.prefix=X}owner&facet=true&facet.missing=true&facet.limit=10',
+            '?facet.field={!key=f1}owner&facet.field={!key=f5 facet.prefix=X}owner&facet.query={!key=f2}category:23&facet.query={!key=f4}category:40&facet=true&facet.missing=true&facet.limit=10',
             urldecode($request->getUri())
         );
     }

--- a/tests/Component/RequestBuilder/FacetSetTest.php
+++ b/tests/Component/RequestBuilder/FacetSetTest.php
@@ -374,7 +374,7 @@ class FacetSetTest extends TestCase
         $this->assertNull($request->getRawData());
 
         $this->assertEquals(
-            '?facet.field={!key=f1}owner&f.owner.facet.contains=foo&f.owner.facet.contains.ignoreCase=true&facet=true&facet.contains=bar&facet.contains.ignoreCase=false',
+            '?facet.field={!key=f1 facet.contains=foo facet.contains.ignoreCase=1}owner&facet=true&facet.contains=bar&facet.contains.ignoreCase=false',
             urldecode($request->getUri())
         );
     }


### PR DESCRIPTION
when using multiple facets on the same field, the facet parameter (prefix, limit etc.) are connected to the field instead of the facet key. therefor, they are valid for all facets on one field.

current solr versions allow local params to the facet.field parameter. therefor, as much parameter as possible should be moved to the facet.field.

i am not sure, whether this can be used directly or whether there should be a switch for that.
apparently, since SOLR 6.6 (eventually earlier), local parameters are possible for the facet.field component.

```
$facetSetCategory = $squery->getFacetSet();
$facetSetCategory->createFacetField('category')->setField('category')->setLimit( 50 )->addExclude('category');
$facetSetArea = $squery->getFacetSet();
$facetSetArea->createFacetField('area')->setField('category')->setPrefix( '1!!area' )->setLimit( 10 )->addExclude('area');
```
thank you
jürgen